### PR TITLE
Adopt latest conventions to prevent deprecation warnings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,4 +2,4 @@
 # tasks file for atom-packages
 
 - apm: name={{ item }} state=latest
-  with_items: atom_packages_packages
+  with_items: "{{ atom_packages_packages }}"


### PR DESCRIPTION
Recent ansible versions prefer `with_items` to be surrounded by quotes and double curly braces, so 

`with_items: atom_packages_packages` becomes `with_items: "{{ atom_packages_packages }}"`

Otherwise, the following deprecation warning is output:

```
...
TASK [hnakamur.atom-packages : apm] ********************************************
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax
('{{atom_packages_packages}}').
This feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False
in ansible.cfg.
...
```
